### PR TITLE
Clean up main scene UI layout

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -366,3 +366,24 @@ Eight seeds were already crowded on a portrait mobile screen. A horizontal scrol
 ### Next recommended step
 
 Test touch/mouse scrolling in Godot and on an Android device. If it feels good, the next UI pass should add clearer visual affordance that the Seed Bar can be swiped horizontally.
+
+## 2026-04-26 - UI cleanup pass
+
+### What changed
+
+- Replaced the stack of five top-level labels with a single cream header panel that holds the title, a butter-yellow harvest basket badge, the hint text, the goal line, and two slim progress bars for baskets and discoveries.
+- Replaced the duplicated grass backdrop behind the grid with a soil-colored frame panel that wraps the grass texture, so the play area has a clear journal-like edge.
+- Replaced the flat `ColorRect` controls backdrop with a rounded cream `StyleBoxFlat` panel that visually anchors the seeds, the water button, and the diary together.
+- Reworked the bed selector into proper tabs with an active-state highlight using `StyleBoxFlat` instead of seed-slot textures, and moved the active bed name onto the tab row.
+- Restyled `Water Garden` as a moss-green primary action button with shadow and rounded corners, and centered it under the seed row.
+- Repositioned and resized `GardenStatusPanel` to fit inside the new bottom panel as two stacked cards (status card + diary card with a heading and separator), and switched the diary entries to bullet lines.
+- Added a `grid_top_offset` field to `GardenGrid` so the main scene can vertically center the 3x3 grid inside its new frame instead of hard-coding the y position.
+- Centralized the new color palette (cream, sage, moss, soil, clay, butter, deep text green) inside `main_scene.gd`, drawn from `progression-and-art-direction.md`.
+
+### Why
+
+The previous layout grew label by label at the top of the screen until five centered labels and two buttons were stacked between y=80 and y=425 with no visual grouping. The grid backdrop was a second copy of the grass texture, which read as flat noise rather than a defined play area. The controls area was a single translucent rectangle that did not separate the seed bar, the water button, and the diary. The bed selector reused seed-slot art that visually competed with the actual seeds.
+
+### Next recommended step
+
+Test the layout in Godot on the 540x960 window override and on a real Android viewport. Then start replacing the placeholder SVGs with the journal-style assets described in the art direction doc.

--- a/scripts/garden/garden_grid.gd
+++ b/scripts/garden/garden_grid.gd
@@ -10,6 +10,7 @@ const GRID_SIZE := 3
 const TILE_SIZE := Vector2(260, 260)
 const TILE_GAP := 24
 const VIEWPORT_WIDTH := 1080
+const DEFAULT_GRID_TOP := 450
 
 var active_bed_id := "starter_bed"
 var beds: Dictionary = {}
@@ -17,6 +18,7 @@ var bed_tile_states: Dictionary = {}
 var selected_seed_id: String = "carrot"
 var tiles: Array[GardenTile] = []
 var discovered_relationships: Dictionary = {}
+var grid_top_offset: int = DEFAULT_GRID_TOP
 
 func _ready() -> void:
 	_create_beds()
@@ -75,7 +77,7 @@ func _create_tiles() -> void:
 		GRID_SIZE * TILE_SIZE.x + (GRID_SIZE - 1) * TILE_GAP,
 		GRID_SIZE * TILE_SIZE.y + (GRID_SIZE - 1) * TILE_GAP
 	)
-	var start_position := Vector2((VIEWPORT_WIDTH - total_size.x) / 2.0, 450)
+	var start_position := Vector2((VIEWPORT_WIDTH - total_size.x) / 2.0, grid_top_offset)
 
 	for y in GRID_SIZE:
 		for x in GRID_SIZE:

--- a/scripts/main_scene.gd
+++ b/scripts/main_scene.gd
@@ -6,35 +6,31 @@ const TARGET_DISCOVERIES := 3
 const GRASS_TEXTURE_PATH := "res://assets/tiles/ground/tile_grass_base.svg"
 
 const COLOR_TEXT_DEEP := Color("#263D25")
-const COLOR_TEXT_SOFT := Color("#4A5C42")
 const COLOR_CREAM := Color("#F1E7C8")
 const COLOR_CREAM_SOFT := Color("#FBF4DD")
+const COLOR_BUTTER := Color("#E7C767")
 const COLOR_SAGE := Color("#AFCB9B")
 const COLOR_MOSS := Color("#627A4E")
 const COLOR_SOIL := Color("#7B5738")
-const COLOR_CLAY := Color("#B86F4B")
-const COLOR_BUTTER := Color("#E7C767")
-const COLOR_PROGRESS_TRACK := Color("#D8C99A")
-const COLOR_PROGRESS_FILL := Color("#7B9B5A")
 
-const HEADER_TOP := 36
-const HEADER_HEIGHT := 200
-const TABS_TOP := HEADER_TOP + HEADER_HEIGHT + 16
-const TABS_HEIGHT := 76
+const TOP_BAR_TOP := 44
+const TOP_BAR_HEIGHT := 76
+const TABS_TOP := TOP_BAR_TOP + TOP_BAR_HEIGHT + 28
+const TABS_HEIGHT := 64
 const GRID_TOP := TABS_TOP + TABS_HEIGHT + 24
-const GRID_HEIGHT := 880
-const BOTTOM_PANEL_TOP := GRID_TOP + GRID_HEIGHT + 16
-const BOTTOM_PANEL_HEIGHT := 1920 - BOTTOM_PANEL_TOP - 28
+const GRID_HEIGHT := 920
+const SEED_BAR_TOP := GRID_TOP + GRID_HEIGHT + 36
+const SEED_BAR_HEIGHT := 170
+const WATER_BUTTON_TOP := SEED_BAR_TOP + SEED_BAR_HEIGHT + 28
+const WATER_BUTTON_HEIGHT := 80
+const STATUS_TOP := WATER_BUTTON_TOP + WATER_BUTTON_HEIGHT + 18
 
 var garden_grid: GardenGrid
 var seed_bar: SeedBar
 var status_panel: GardenStatusPanel
 var selected_seed_id := "carrot"
 var harvest_value_label: Label
-var goal_progress_label: Label
-var harvest_progress_bar: ProgressBar
-var discovery_progress_bar: ProgressBar
-var bed_label: Label
+var diary_button_label: Label
 var starter_bed_button: Button
 var herb_bed_button: Button
 var water_button: Button
@@ -44,15 +40,13 @@ var herb_bed_unlocked := false
 
 func _ready() -> void:
 	_create_background()
-	_create_header_panel()
+	_create_top_bar()
 	_create_bed_tabs()
 	_create_garden_frame()
 	_create_garden_grid()
-	_create_bottom_panel()
 	_create_seed_bar()
-	_create_care_button()
+	_create_water_button()
 	_create_status_panel()
-	_update_goal_display()
 
 func _create_background() -> void:
 	var background := TextureRect.new()
@@ -68,132 +62,94 @@ func _create_background() -> void:
 
 	var vignette := ColorRect.new()
 	vignette.name = "Vignette"
-	vignette.color = Color(0.16, 0.20, 0.12, 0.18)
+	vignette.color = Color(0.16, 0.20, 0.12, 0.14)
 	vignette.position = Vector2.ZERO
 	vignette.size = Vector2(1080, 1920)
 	vignette.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	add_child(vignette)
 
-func _create_header_panel() -> void:
-	var panel := _make_panel(COLOR_CREAM, COLOR_SOIL, 28, 4)
-	panel.name = "HeaderPanel"
-	panel.position = Vector2(28, HEADER_TOP)
-	panel.size = Vector2(1024, HEADER_HEIGHT)
-	add_child(panel)
+func _create_top_bar() -> void:
+	var diary_button := Button.new()
+	diary_button.name = "DiaryButton"
+	diary_button.position = Vector2(44, TOP_BAR_TOP)
+	diary_button.size = Vector2(220, TOP_BAR_HEIGHT)
+	diary_button.focus_mode = Control.FOCUS_NONE
+	_apply_pill_theme(diary_button, COLOR_CREAM_SOFT, COLOR_SOIL)
+	diary_button.pressed.connect(_on_diary_button_pressed)
+	add_child(diary_button)
 
-	var title := Label.new()
-	title.name = "Title"
-	title.text = "Sprout & Soil"
-	title.position = Vector2(40, 18)
-	title.size = Vector2(620, 60)
-	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	title.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-	title.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
-	title.add_theme_font_size_override("font_size", 44)
-	panel.add_child(title)
+	diary_button_label = Label.new()
+	diary_button_label.name = "DiaryButtonLabel"
+	diary_button_label.text = "Diary"
+	diary_button_label.position = Vector2(0, 0)
+	diary_button_label.size = diary_button.size
+	diary_button_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	diary_button_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	diary_button_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	diary_button_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
+	diary_button_label.add_theme_font_size_override("font_size", 26)
+	diary_button.add_child(diary_button_label)
 
-	var basket_badge := _make_panel(COLOR_BUTTER, COLOR_SOIL, 22, 3)
-	basket_badge.name = "BasketBadge"
-	basket_badge.position = Vector2(720, 22)
-	basket_badge.size = Vector2(264, 60)
-	panel.add_child(basket_badge)
+	var basket_pill := _make_panel(COLOR_BUTTER, COLOR_SOIL, 28, 3)
+	basket_pill.name = "BasketPill"
+	basket_pill.position = Vector2(816, TOP_BAR_TOP)
+	basket_pill.size = Vector2(220, TOP_BAR_HEIGHT)
+	add_child(basket_pill)
 
 	var basket_label := Label.new()
 	basket_label.name = "BasketLabel"
 	basket_label.text = "Baskets"
 	basket_label.position = Vector2(20, 0)
-	basket_label.size = Vector2(140, 60)
+	basket_label.size = Vector2(120, TOP_BAR_HEIGHT)
 	basket_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	basket_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
-	basket_label.add_theme_font_size_override("font_size", 24)
-	basket_badge.add_child(basket_label)
+	basket_label.add_theme_font_size_override("font_size", 22)
+	basket_pill.add_child(basket_label)
 
 	harvest_value_label = Label.new()
 	harvest_value_label.name = "HarvestValueLabel"
 	harvest_value_label.text = "0"
-	harvest_value_label.position = Vector2(150, 0)
-	harvest_value_label.size = Vector2(110, 60)
+	harvest_value_label.position = Vector2(140, 0)
+	harvest_value_label.size = Vector2(60, TOP_BAR_HEIGHT)
 	harvest_value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	harvest_value_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	harvest_value_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
 	harvest_value_label.add_theme_font_size_override("font_size", 30)
-	basket_badge.add_child(harvest_value_label)
-
-	var hint := Label.new()
-	hint.name = "Hint"
-	hint.text = "Choose a seed, then tap an empty bed."
-	hint.position = Vector2(40, 84)
-	hint.size = Vector2(944, 32)
-	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	hint.add_theme_color_override("font_color", COLOR_TEXT_SOFT)
-	hint.add_theme_font_size_override("font_size", 22)
-	panel.add_child(hint)
-
-	goal_progress_label = Label.new()
-	goal_progress_label.name = "GoalProgressLabel"
-	goal_progress_label.position = Vector2(40, 122)
-	goal_progress_label.size = Vector2(944, 28)
-	goal_progress_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	goal_progress_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
-	goal_progress_label.add_theme_font_size_override("font_size", 20)
-	panel.add_child(goal_progress_label)
-
-	harvest_progress_bar = _make_progress_bar()
-	harvest_progress_bar.name = "HarvestProgressBar"
-	harvest_progress_bar.position = Vector2(40, 156)
-	harvest_progress_bar.size = Vector2(460, 22)
-	harvest_progress_bar.max_value = TARGET_HARVEST
-	panel.add_child(harvest_progress_bar)
-
-	discovery_progress_bar = _make_progress_bar()
-	discovery_progress_bar.name = "DiscoveryProgressBar"
-	discovery_progress_bar.position = Vector2(524, 156)
-	discovery_progress_bar.size = Vector2(460, 22)
-	discovery_progress_bar.max_value = TARGET_DISCOVERIES
-	panel.add_child(discovery_progress_bar)
+	basket_pill.add_child(harvest_value_label)
 
 func _create_bed_tabs() -> void:
 	var tab_row := Control.new()
 	tab_row.name = "BedTabs"
-	tab_row.position = Vector2(28, TABS_TOP)
-	tab_row.size = Vector2(1024, TABS_HEIGHT)
+	tab_row.position = Vector2(0, TABS_TOP)
+	tab_row.size = Vector2(1080, TABS_HEIGHT)
 	add_child(tab_row)
 
-	bed_label = Label.new()
-	bed_label.name = "BedLabel"
-	bed_label.text = "Starter Bed"
-	bed_label.position = Vector2(0, 0)
-	bed_label.size = Vector2(360, TABS_HEIGHT)
-	bed_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	bed_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-	bed_label.add_theme_color_override("font_color", COLOR_CREAM)
-	bed_label.add_theme_color_override("font_shadow_color", Color(0.10, 0.16, 0.08, 0.85))
-	bed_label.add_theme_constant_override("shadow_offset_x", 0)
-	bed_label.add_theme_constant_override("shadow_offset_y", 3)
-	bed_label.add_theme_font_size_override("font_size", 30)
-	tab_row.add_child(bed_label)
+	var tab_width := 200
+	var tab_gap := 16
+	var total := tab_width * 2 + tab_gap
+	var start_x: float = (1080 - total) / 2.0
 
 	starter_bed_button = Button.new()
 	starter_bed_button.name = "StarterBedButton"
 	starter_bed_button.text = "Starter"
-	starter_bed_button.position = Vector2(560, 0)
-	starter_bed_button.size = Vector2(220, TABS_HEIGHT)
+	starter_bed_button.position = Vector2(start_x, 0)
+	starter_bed_button.size = Vector2(tab_width, TABS_HEIGHT)
 	_apply_tab_theme(starter_bed_button)
 	starter_bed_button.pressed.connect(_on_starter_bed_pressed)
 	tab_row.add_child(starter_bed_button)
 
 	herb_bed_button = Button.new()
 	herb_bed_button.name = "HerbBedButton"
-	herb_bed_button.text = "Herb (locked)"
-	herb_bed_button.position = Vector2(794, 0)
-	herb_bed_button.size = Vector2(230, TABS_HEIGHT)
+	herb_bed_button.text = "Herb"
+	herb_bed_button.position = Vector2(start_x + tab_width + tab_gap, 0)
+	herb_bed_button.size = Vector2(tab_width, TABS_HEIGHT)
 	_apply_tab_theme(herb_bed_button)
 	herb_bed_button.disabled = true
 	herb_bed_button.pressed.connect(_on_herb_bed_pressed)
 	tab_row.add_child(herb_bed_button)
 
 func _create_garden_frame() -> void:
-	var frame := _make_panel(COLOR_SOIL, COLOR_CLAY, 32, 5)
+	var frame := _make_panel(COLOR_SOIL, Color("#B86F4B"), 32, 5)
 	frame.name = "GardenFrame"
 	frame.position = Vector2(28, GRID_TOP)
 	frame.size = Vector2(1024, GRID_HEIGHT)
@@ -209,18 +165,10 @@ func _create_garden_frame() -> void:
 	inner.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	frame.add_child(inner)
 
-	var inner_shade := ColorRect.new()
-	inner_shade.name = "GardenSoilShade"
-	inner_shade.color = Color(0.10, 0.18, 0.08, 0.18)
-	inner_shade.position = Vector2(20, 20)
-	inner_shade.size = inner.size
-	inner_shade.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	frame.add_child(inner_shade)
-
 func _create_garden_grid() -> void:
 	garden_grid = GardenGrid.new()
 	garden_grid.name = "GardenGrid"
-	garden_grid.grid_top_offset = GRID_TOP + 26
+	garden_grid.grid_top_offset = GRID_TOP + 46
 	garden_grid.set_selected_seed(selected_seed_id)
 	garden_grid.relationship_discovered.connect(_on_relationship_discovered)
 	garden_grid.garden_message.connect(_on_garden_message)
@@ -228,27 +176,20 @@ func _create_garden_grid() -> void:
 	garden_grid.active_bed_changed.connect(_on_active_bed_changed)
 	add_child(garden_grid)
 
-func _create_bottom_panel() -> void:
-	var panel := _make_panel(COLOR_CREAM_SOFT, COLOR_SOIL, 32, 4)
-	panel.name = "BottomPanel"
-	panel.position = Vector2(28, BOTTOM_PANEL_TOP)
-	panel.size = Vector2(1024, BOTTOM_PANEL_HEIGHT)
-	add_child(panel)
-
 func _create_seed_bar() -> void:
 	seed_bar = SeedBar.new()
 	seed_bar.name = "SeedBar"
-	seed_bar.position = Vector2(56, BOTTOM_PANEL_TOP + 24)
+	seed_bar.position = Vector2(56, SEED_BAR_TOP)
 	seed_bar.setup(AVAILABLE_SEEDS, selected_seed_id)
 	seed_bar.seed_selected.connect(_on_seed_selected)
 	add_child(seed_bar)
 
-func _create_care_button() -> void:
+func _create_water_button() -> void:
 	water_button = Button.new()
 	water_button.name = "WaterGardenButton"
 	water_button.text = "Water Garden"
-	water_button.position = Vector2(360, BOTTOM_PANEL_TOP + 250)
-	water_button.size = Vector2(360, 86)
+	water_button.position = Vector2(360, WATER_BUTTON_TOP)
+	water_button.size = Vector2(360, WATER_BUTTON_HEIGHT)
 	_apply_primary_button_theme(water_button)
 	water_button.pressed.connect(_on_water_button_pressed)
 	add_child(water_button)
@@ -256,9 +197,12 @@ func _create_care_button() -> void:
 func _create_status_panel() -> void:
 	status_panel = GardenStatusPanel.new()
 	status_panel.name = "GardenStatusPanel"
-	status_panel.position = Vector2(56, BOTTOM_PANEL_TOP + 350)
+	status_panel.position = Vector2(0, 0)
 	status_panel.setup()
 	add_child(status_panel)
+
+	status_panel.status_label.position = Vector2(60, STATUS_TOP)
+	status_panel.status_label.size = Vector2(960, 60)
 
 func _make_panel(bg: Color, border: Color, radius: int, border_width: int) -> Panel:
 	var panel := Panel.new()
@@ -267,30 +211,31 @@ func _make_panel(bg: Color, border: Color, radius: int, border_width: int) -> Pa
 	style.border_color = border
 	style.set_border_width_all(border_width)
 	style.set_corner_radius_all(radius)
-	style.shadow_color = Color(0.12, 0.10, 0.06, 0.30)
+	style.shadow_color = Color(0.12, 0.10, 0.06, 0.28)
 	style.shadow_size = 6
 	style.shadow_offset = Vector2(0, 4)
 	panel.add_theme_stylebox_override("panel", style)
 	return panel
 
-func _make_progress_bar() -> ProgressBar:
-	var bar := ProgressBar.new()
-	bar.show_percentage = false
-	bar.min_value = 0
+func _apply_pill_theme(button: Button, bg: Color, border: Color) -> void:
+	var normal := StyleBoxFlat.new()
+	normal.bg_color = bg
+	normal.border_color = border
+	normal.set_border_width_all(3)
+	normal.set_corner_radius_all(28)
+	normal.shadow_color = Color(0.12, 0.10, 0.06, 0.25)
+	normal.shadow_size = 5
+	normal.shadow_offset = Vector2(0, 3)
 
-	var bg_style := StyleBoxFlat.new()
-	bg_style.bg_color = COLOR_PROGRESS_TRACK
-	bg_style.border_color = COLOR_SOIL
-	bg_style.set_border_width_all(2)
-	bg_style.set_corner_radius_all(11)
+	var hover := normal.duplicate() as StyleBoxFlat
+	hover.bg_color = Color(bg.r * 0.96, bg.g * 0.96, bg.b * 0.96)
 
-	var fill_style := StyleBoxFlat.new()
-	fill_style.bg_color = COLOR_PROGRESS_FILL
-	fill_style.set_corner_radius_all(11)
+	var pressed := normal.duplicate() as StyleBoxFlat
+	pressed.bg_color = Color(bg.r * 0.90, bg.g * 0.90, bg.b * 0.90)
 
-	bar.add_theme_stylebox_override("background", bg_style)
-	bar.add_theme_stylebox_override("fill", fill_style)
-	return bar
+	button.add_theme_stylebox_override("normal", normal)
+	button.add_theme_stylebox_override("hover", hover)
+	button.add_theme_stylebox_override("pressed", pressed)
 
 func _apply_tab_theme(button: Button) -> void:
 	var normal := StyleBoxFlat.new()
@@ -321,7 +266,7 @@ func _apply_tab_theme(button: Button) -> void:
 	button.add_theme_color_override("font_hover_color", COLOR_TEXT_DEEP)
 	button.add_theme_color_override("font_pressed_color", COLOR_TEXT_DEEP)
 	button.add_theme_color_override("font_disabled_color", COLOR_TEXT_DEEP)
-	button.add_theme_font_size_override("font_size", 26)
+	button.add_theme_font_size_override("font_size", 24)
 	button.focus_mode = Control.FOCUS_NONE
 
 func _apply_primary_button_theme(button: Button) -> void:
@@ -352,7 +297,7 @@ func _apply_primary_button_theme(button: Button) -> void:
 	button.add_theme_color_override("font_hover_color", COLOR_CREAM_SOFT)
 	button.add_theme_color_override("font_pressed_color", COLOR_CREAM)
 	button.add_theme_color_override("font_disabled_color", COLOR_CREAM)
-	button.add_theme_font_size_override("font_size", 30)
+	button.add_theme_font_size_override("font_size", 28)
 	button.focus_mode = Control.FOCUS_NONE
 
 func _on_seed_selected(seed_id: String) -> void:
@@ -367,14 +312,17 @@ func _on_starter_bed_pressed() -> void:
 
 func _on_herb_bed_pressed() -> void:
 	if not herb_bed_unlocked:
-		status_panel.show_message("Complete the Starter Bed goal to unlock the Herb Bed.")
+		status_panel.show_message("Finish the Starter Bed to unlock the Herb Bed.")
 		return
 
 	garden_grid.switch_bed("herb_bed")
 
+func _on_diary_button_pressed() -> void:
+	status_panel.toggle_diary()
+
 func _on_relationship_discovered(discovery: Dictionary) -> void:
 	status_panel.show_discovery(discovery)
-	_update_goal_display()
+	_update_diary_label()
 	_check_starter_goal()
 
 func _on_garden_message(message: String) -> void:
@@ -383,30 +331,21 @@ func _on_garden_message(message: String) -> void:
 func _on_harvest_completed(harvest_result: Dictionary) -> void:
 	total_harvest += harvest_result.get("yield_amount", 0)
 	harvest_value_label.text = "%s" % total_harvest
-	_update_goal_display()
 	_check_starter_goal()
 
 func _on_active_bed_changed(bed: GardenBed) -> void:
-	bed_label.text = bed.display_name
 	starter_bed_button.disabled = bed.bed_id == "starter_bed"
 	herb_bed_button.disabled = bed.bed_id == "herb_bed" or not herb_bed_unlocked
 
-func _update_goal_display() -> void:
-	var discoveries: int = status_panel.get_diary_entry_count() if status_panel != null else 0
-	var harvest_clamped: int = min(total_harvest, TARGET_HARVEST)
-	var discoveries_clamped: int = min(discoveries, TARGET_DISCOVERIES)
+func _update_diary_label() -> void:
+	if diary_button_label == null or status_panel == null:
+		return
 
-	goal_progress_label.text = "Goal:  %s/%s baskets    %s/%s discoveries" % [
-		harvest_clamped,
-		TARGET_HARVEST,
-		discoveries_clamped,
-		TARGET_DISCOVERIES
-	]
-
-	if harvest_progress_bar != null:
-		harvest_progress_bar.value = harvest_clamped
-	if discovery_progress_bar != null:
-		discovery_progress_bar.value = discoveries_clamped
+	var count := status_panel.get_diary_entry_count()
+	if count <= 0:
+		diary_button_label.text = "Diary"
+	else:
+		diary_button_label.text = "Diary  %s" % count
 
 func _check_starter_goal() -> void:
 	if starter_goal_completed:
@@ -420,6 +359,5 @@ func _check_starter_goal() -> void:
 
 	starter_goal_completed = true
 	herb_bed_unlocked = true
-	herb_bed_button.text = "Herb"
 	herb_bed_button.disabled = false
-	status_panel.show_message("Starter Bed complete!\nHerb Bed unlocked.")
+	status_panel.show_message("Herb Bed unlocked.")

--- a/scripts/main_scene.gd
+++ b/scripts/main_scene.gd
@@ -1,19 +1,39 @@
 extends Node2D
 
 const AVAILABLE_SEEDS := ["carrot", "onion", "tomato", "basil", "potato", "bean", "corn", "squash"]
-const TEXT_COLOR := Color(0.16, 0.24, 0.14)
 const TARGET_HARVEST := 8
 const TARGET_DISCOVERIES := 3
 const GRASS_TEXTURE_PATH := "res://assets/tiles/ground/tile_grass_base.svg"
-const SEED_SLOT_TEXTURE_PATH := "res://assets/ui/seed_bar/ui_seed_slot.svg"
-const SEED_SLOT_SELECTED_TEXTURE_PATH := "res://assets/ui/seed_bar/ui_seed_slot_selected.svg"
+
+const COLOR_TEXT_DEEP := Color("#263D25")
+const COLOR_TEXT_SOFT := Color("#4A5C42")
+const COLOR_CREAM := Color("#F1E7C8")
+const COLOR_CREAM_SOFT := Color("#FBF4DD")
+const COLOR_SAGE := Color("#AFCB9B")
+const COLOR_MOSS := Color("#627A4E")
+const COLOR_SOIL := Color("#7B5738")
+const COLOR_CLAY := Color("#B86F4B")
+const COLOR_BUTTER := Color("#E7C767")
+const COLOR_PROGRESS_TRACK := Color("#D8C99A")
+const COLOR_PROGRESS_FILL := Color("#7B9B5A")
+
+const HEADER_TOP := 36
+const HEADER_HEIGHT := 200
+const TABS_TOP := HEADER_TOP + HEADER_HEIGHT + 16
+const TABS_HEIGHT := 76
+const GRID_TOP := TABS_TOP + TABS_HEIGHT + 24
+const GRID_HEIGHT := 880
+const BOTTOM_PANEL_TOP := GRID_TOP + GRID_HEIGHT + 16
+const BOTTOM_PANEL_HEIGHT := 1920 - BOTTOM_PANEL_TOP - 28
 
 var garden_grid: GardenGrid
 var seed_bar: SeedBar
 var status_panel: GardenStatusPanel
 var selected_seed_id := "carrot"
-var harvest_label: Label
-var goal_label: Label
+var harvest_value_label: Label
+var goal_progress_label: Label
+var harvest_progress_bar: ProgressBar
+var discovery_progress_bar: ProgressBar
 var bed_label: Label
 var starter_bed_button: Button
 var herb_bed_button: Button
@@ -24,17 +44,15 @@ var herb_bed_unlocked := false
 
 func _ready() -> void:
 	_create_background()
-	_create_garden_backdrop()
-	_create_title()
-	_create_harvest_counter()
-	_create_goal_label()
-	_create_bed_label()
-	_create_bed_selector()
+	_create_header_panel()
+	_create_bed_tabs()
+	_create_garden_frame()
 	_create_garden_grid()
+	_create_bottom_panel()
 	_create_seed_bar()
 	_create_care_button()
 	_create_status_panel()
-	_update_goal_label()
+	_update_goal_display()
 
 func _create_background() -> void:
 	var background := TextureRect.new()
@@ -48,48 +66,161 @@ func _create_background() -> void:
 	add_child(background)
 	move_child(background, 0)
 
-func _create_garden_backdrop() -> void:
-	var garden_backdrop := TextureRect.new()
-	garden_backdrop.name = "GardenBackdrop"
-	garden_backdrop.texture = load(GRASS_TEXTURE_PATH)
-	garden_backdrop.position = Vector2(28, 430)
-	garden_backdrop.size = Vector2(1024, 890)
-	garden_backdrop.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	garden_backdrop.stretch_mode = TextureRect.STRETCH_SCALE
-	garden_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(garden_backdrop)
+	var vignette := ColorRect.new()
+	vignette.name = "Vignette"
+	vignette.color = Color(0.16, 0.20, 0.12, 0.18)
+	vignette.position = Vector2.ZERO
+	vignette.size = Vector2(1080, 1920)
+	vignette.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(vignette)
 
-	var controls_backdrop := ColorRect.new()
-	controls_backdrop.name = "ControlsBackdrop"
-	controls_backdrop.color = Color(0.94, 0.86, 0.68, 0.88)
-	controls_backdrop.position = Vector2(28, 1325)
-	controls_backdrop.size = Vector2(1024, 555)
-	add_child(controls_backdrop)
+func _create_header_panel() -> void:
+	var panel := _make_panel(COLOR_CREAM, COLOR_SOIL, 28, 4)
+	panel.name = "HeaderPanel"
+	panel.position = Vector2(28, HEADER_TOP)
+	panel.size = Vector2(1024, HEADER_HEIGHT)
+	add_child(panel)
 
-func _create_title() -> void:
 	var title := Label.new()
 	title.name = "Title"
 	title.text = "Sprout & Soil"
-	title.position = Vector2(0, 80)
-	title.size = Vector2(1080, 80)
-	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	title.add_theme_color_override("font_color", TEXT_COLOR)
-	title.add_theme_font_size_override("font_size", 40)
-	add_child(title)
+	title.position = Vector2(40, 18)
+	title.size = Vector2(620, 60)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	title.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	title.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
+	title.add_theme_font_size_override("font_size", 44)
+	panel.add_child(title)
+
+	var basket_badge := _make_panel(COLOR_BUTTER, COLOR_SOIL, 22, 3)
+	basket_badge.name = "BasketBadge"
+	basket_badge.position = Vector2(720, 22)
+	basket_badge.size = Vector2(264, 60)
+	panel.add_child(basket_badge)
+
+	var basket_label := Label.new()
+	basket_label.name = "BasketLabel"
+	basket_label.text = "Baskets"
+	basket_label.position = Vector2(20, 0)
+	basket_label.size = Vector2(140, 60)
+	basket_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	basket_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
+	basket_label.add_theme_font_size_override("font_size", 24)
+	basket_badge.add_child(basket_label)
+
+	harvest_value_label = Label.new()
+	harvest_value_label.name = "HarvestValueLabel"
+	harvest_value_label.text = "0"
+	harvest_value_label.position = Vector2(150, 0)
+	harvest_value_label.size = Vector2(110, 60)
+	harvest_value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	harvest_value_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	harvest_value_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
+	harvest_value_label.add_theme_font_size_override("font_size", 30)
+	basket_badge.add_child(harvest_value_label)
 
 	var hint := Label.new()
 	hint.name = "Hint"
 	hint.text = "Choose a seed, then tap an empty bed."
-	hint.position = Vector2(0, 155)
-	hint.size = Vector2(1080, 60)
-	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	hint.add_theme_color_override("font_color", TEXT_COLOR)
-	hint.add_theme_font_size_override("font_size", 28)
-	add_child(hint)
+	hint.position = Vector2(40, 84)
+	hint.size = Vector2(944, 32)
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	hint.add_theme_color_override("font_color", COLOR_TEXT_SOFT)
+	hint.add_theme_font_size_override("font_size", 22)
+	panel.add_child(hint)
+
+	goal_progress_label = Label.new()
+	goal_progress_label.name = "GoalProgressLabel"
+	goal_progress_label.position = Vector2(40, 122)
+	goal_progress_label.size = Vector2(944, 28)
+	goal_progress_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	goal_progress_label.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
+	goal_progress_label.add_theme_font_size_override("font_size", 20)
+	panel.add_child(goal_progress_label)
+
+	harvest_progress_bar = _make_progress_bar()
+	harvest_progress_bar.name = "HarvestProgressBar"
+	harvest_progress_bar.position = Vector2(40, 156)
+	harvest_progress_bar.size = Vector2(460, 22)
+	harvest_progress_bar.max_value = TARGET_HARVEST
+	panel.add_child(harvest_progress_bar)
+
+	discovery_progress_bar = _make_progress_bar()
+	discovery_progress_bar.name = "DiscoveryProgressBar"
+	discovery_progress_bar.position = Vector2(524, 156)
+	discovery_progress_bar.size = Vector2(460, 22)
+	discovery_progress_bar.max_value = TARGET_DISCOVERIES
+	panel.add_child(discovery_progress_bar)
+
+func _create_bed_tabs() -> void:
+	var tab_row := Control.new()
+	tab_row.name = "BedTabs"
+	tab_row.position = Vector2(28, TABS_TOP)
+	tab_row.size = Vector2(1024, TABS_HEIGHT)
+	add_child(tab_row)
+
+	bed_label = Label.new()
+	bed_label.name = "BedLabel"
+	bed_label.text = "Starter Bed"
+	bed_label.position = Vector2(0, 0)
+	bed_label.size = Vector2(360, TABS_HEIGHT)
+	bed_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	bed_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	bed_label.add_theme_color_override("font_color", COLOR_CREAM)
+	bed_label.add_theme_color_override("font_shadow_color", Color(0.10, 0.16, 0.08, 0.85))
+	bed_label.add_theme_constant_override("shadow_offset_x", 0)
+	bed_label.add_theme_constant_override("shadow_offset_y", 3)
+	bed_label.add_theme_font_size_override("font_size", 30)
+	tab_row.add_child(bed_label)
+
+	starter_bed_button = Button.new()
+	starter_bed_button.name = "StarterBedButton"
+	starter_bed_button.text = "Starter"
+	starter_bed_button.position = Vector2(560, 0)
+	starter_bed_button.size = Vector2(220, TABS_HEIGHT)
+	_apply_tab_theme(starter_bed_button)
+	starter_bed_button.pressed.connect(_on_starter_bed_pressed)
+	tab_row.add_child(starter_bed_button)
+
+	herb_bed_button = Button.new()
+	herb_bed_button.name = "HerbBedButton"
+	herb_bed_button.text = "Herb (locked)"
+	herb_bed_button.position = Vector2(794, 0)
+	herb_bed_button.size = Vector2(230, TABS_HEIGHT)
+	_apply_tab_theme(herb_bed_button)
+	herb_bed_button.disabled = true
+	herb_bed_button.pressed.connect(_on_herb_bed_pressed)
+	tab_row.add_child(herb_bed_button)
+
+func _create_garden_frame() -> void:
+	var frame := _make_panel(COLOR_SOIL, COLOR_CLAY, 32, 5)
+	frame.name = "GardenFrame"
+	frame.position = Vector2(28, GRID_TOP)
+	frame.size = Vector2(1024, GRID_HEIGHT)
+	add_child(frame)
+
+	var inner := TextureRect.new()
+	inner.name = "GardenSoil"
+	inner.texture = load(GRASS_TEXTURE_PATH)
+	inner.position = Vector2(20, 20)
+	inner.size = Vector2(984, GRID_HEIGHT - 40)
+	inner.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	inner.stretch_mode = TextureRect.STRETCH_SCALE
+	inner.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	frame.add_child(inner)
+
+	var inner_shade := ColorRect.new()
+	inner_shade.name = "GardenSoilShade"
+	inner_shade.color = Color(0.10, 0.18, 0.08, 0.18)
+	inner_shade.position = Vector2(20, 20)
+	inner_shade.size = inner.size
+	inner_shade.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	frame.add_child(inner_shade)
 
 func _create_garden_grid() -> void:
 	garden_grid = GardenGrid.new()
 	garden_grid.name = "GardenGrid"
+	garden_grid.grid_top_offset = GRID_TOP + 26
 	garden_grid.set_selected_seed(selected_seed_id)
 	garden_grid.relationship_discovered.connect(_on_relationship_discovered)
 	garden_grid.garden_message.connect(_on_garden_message)
@@ -97,62 +228,17 @@ func _create_garden_grid() -> void:
 	garden_grid.active_bed_changed.connect(_on_active_bed_changed)
 	add_child(garden_grid)
 
-func _create_harvest_counter() -> void:
-	harvest_label = Label.new()
-	harvest_label.name = "HarvestLabel"
-	harvest_label.text = "Harvest Basket: 0"
-	harvest_label.position = Vector2(0, 220)
-	harvest_label.size = Vector2(1080, 50)
-	harvest_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	harvest_label.add_theme_color_override("font_color", TEXT_COLOR)
-	harvest_label.add_theme_font_size_override("font_size", 28)
-	add_child(harvest_label)
-
-func _create_goal_label() -> void:
-	goal_label = Label.new()
-	goal_label.name = "GoalLabel"
-	goal_label.position = Vector2(0, 270)
-	goal_label.size = Vector2(1080, 45)
-	goal_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	goal_label.add_theme_color_override("font_color", TEXT_COLOR)
-	goal_label.add_theme_font_size_override("font_size", 24)
-	add_child(goal_label)
-
-func _create_bed_label() -> void:
-	bed_label = Label.new()
-	bed_label.name = "BedLabel"
-	bed_label.text = "Starter Bed"
-	bed_label.position = Vector2(0, 315)
-	bed_label.size = Vector2(1080, 50)
-	bed_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	bed_label.add_theme_color_override("font_color", TEXT_COLOR)
-	bed_label.add_theme_font_size_override("font_size", 30)
-	add_child(bed_label)
-
-func _create_bed_selector() -> void:
-	starter_bed_button = Button.new()
-	starter_bed_button.name = "StarterBedButton"
-	starter_bed_button.text = "Starter"
-	starter_bed_button.position = Vector2(330, 365)
-	starter_bed_button.size = Vector2(190, 60)
-	_apply_button_theme(starter_bed_button)
-	starter_bed_button.pressed.connect(_on_starter_bed_pressed)
-	add_child(starter_bed_button)
-
-	herb_bed_button = Button.new()
-	herb_bed_button.name = "HerbBedButton"
-	herb_bed_button.text = "Herb Locked"
-	herb_bed_button.position = Vector2(560, 365)
-	herb_bed_button.size = Vector2(190, 60)
-	_apply_button_theme(herb_bed_button)
-	herb_bed_button.disabled = true
-	herb_bed_button.pressed.connect(_on_herb_bed_pressed)
-	add_child(herb_bed_button)
+func _create_bottom_panel() -> void:
+	var panel := _make_panel(COLOR_CREAM_SOFT, COLOR_SOIL, 32, 4)
+	panel.name = "BottomPanel"
+	panel.position = Vector2(28, BOTTOM_PANEL_TOP)
+	panel.size = Vector2(1024, BOTTOM_PANEL_HEIGHT)
+	add_child(panel)
 
 func _create_seed_bar() -> void:
 	seed_bar = SeedBar.new()
 	seed_bar.name = "SeedBar"
-	seed_bar.position = Vector2(0, 1300)
+	seed_bar.position = Vector2(56, BOTTOM_PANEL_TOP + 24)
 	seed_bar.setup(AVAILABLE_SEEDS, selected_seed_id)
 	seed_bar.seed_selected.connect(_on_seed_selected)
 	add_child(seed_bar)
@@ -161,50 +247,113 @@ func _create_care_button() -> void:
 	water_button = Button.new()
 	water_button.name = "WaterGardenButton"
 	water_button.text = "Water Garden"
-	water_button.position = Vector2(390, 1500)
-	water_button.size = Vector2(300, 80)
-	_apply_button_theme(water_button)
+	water_button.position = Vector2(360, BOTTOM_PANEL_TOP + 250)
+	water_button.size = Vector2(360, 86)
+	_apply_primary_button_theme(water_button)
 	water_button.pressed.connect(_on_water_button_pressed)
 	add_child(water_button)
 
 func _create_status_panel() -> void:
 	status_panel = GardenStatusPanel.new()
 	status_panel.name = "GardenStatusPanel"
-	status_panel.position = Vector2(0, 1600)
+	status_panel.position = Vector2(56, BOTTOM_PANEL_TOP + 350)
 	status_panel.setup()
 	add_child(status_panel)
 
-func _apply_button_theme(button: Button) -> void:
-	var normal_style := StyleBoxTexture.new()
-	normal_style.texture = load(SEED_SLOT_TEXTURE_PATH)
-	normal_style.content_margin_left = 14
-	normal_style.content_margin_top = 14
-	normal_style.content_margin_right = 14
-	normal_style.content_margin_bottom = 14
+func _make_panel(bg: Color, border: Color, radius: int, border_width: int) -> Panel:
+	var panel := Panel.new()
+	var style := StyleBoxFlat.new()
+	style.bg_color = bg
+	style.border_color = border
+	style.set_border_width_all(border_width)
+	style.set_corner_radius_all(radius)
+	style.shadow_color = Color(0.12, 0.10, 0.06, 0.30)
+	style.shadow_size = 6
+	style.shadow_offset = Vector2(0, 4)
+	panel.add_theme_stylebox_override("panel", style)
+	return panel
 
-	var hover_style := StyleBoxTexture.new()
-	hover_style.texture = load(SEED_SLOT_SELECTED_TEXTURE_PATH)
-	hover_style.content_margin_left = 14
-	hover_style.content_margin_top = 14
-	hover_style.content_margin_right = 14
-	hover_style.content_margin_bottom = 14
+func _make_progress_bar() -> ProgressBar:
+	var bar := ProgressBar.new()
+	bar.show_percentage = false
+	bar.min_value = 0
 
-	var disabled_style := StyleBoxTexture.new()
-	disabled_style.texture = load(SEED_SLOT_SELECTED_TEXTURE_PATH)
-	disabled_style.content_margin_left = 14
-	disabled_style.content_margin_top = 14
-	disabled_style.content_margin_right = 14
-	disabled_style.content_margin_bottom = 14
+	var bg_style := StyleBoxFlat.new()
+	bg_style.bg_color = COLOR_PROGRESS_TRACK
+	bg_style.border_color = COLOR_SOIL
+	bg_style.set_border_width_all(2)
+	bg_style.set_corner_radius_all(11)
 
-	button.add_theme_stylebox_override("normal", normal_style)
-	button.add_theme_stylebox_override("hover", hover_style)
-	button.add_theme_stylebox_override("pressed", hover_style)
-	button.add_theme_stylebox_override("disabled", disabled_style)
-	button.add_theme_color_override("font_color", TEXT_COLOR)
-	button.add_theme_color_override("font_hover_color", TEXT_COLOR)
-	button.add_theme_color_override("font_pressed_color", TEXT_COLOR)
-	button.add_theme_color_override("font_disabled_color", TEXT_COLOR)
-	button.add_theme_font_size_override("font_size", 18)
+	var fill_style := StyleBoxFlat.new()
+	fill_style.bg_color = COLOR_PROGRESS_FILL
+	fill_style.set_corner_radius_all(11)
+
+	bar.add_theme_stylebox_override("background", bg_style)
+	bar.add_theme_stylebox_override("fill", fill_style)
+	return bar
+
+func _apply_tab_theme(button: Button) -> void:
+	var normal := StyleBoxFlat.new()
+	normal.bg_color = COLOR_SAGE
+	normal.border_color = COLOR_MOSS
+	normal.set_border_width_all(3)
+	normal.set_corner_radius_all(20)
+
+	var hover := normal.duplicate() as StyleBoxFlat
+	hover.bg_color = Color("#C0D6AC")
+
+	var pressed := normal.duplicate() as StyleBoxFlat
+	pressed.bg_color = COLOR_CREAM
+	pressed.border_color = COLOR_SOIL
+	pressed.set_border_width_all(4)
+
+	var disabled := StyleBoxFlat.new()
+	disabled.bg_color = COLOR_CREAM
+	disabled.border_color = COLOR_SOIL
+	disabled.set_border_width_all(4)
+	disabled.set_corner_radius_all(20)
+
+	button.add_theme_stylebox_override("normal", normal)
+	button.add_theme_stylebox_override("hover", hover)
+	button.add_theme_stylebox_override("pressed", pressed)
+	button.add_theme_stylebox_override("disabled", disabled)
+	button.add_theme_color_override("font_color", COLOR_TEXT_DEEP)
+	button.add_theme_color_override("font_hover_color", COLOR_TEXT_DEEP)
+	button.add_theme_color_override("font_pressed_color", COLOR_TEXT_DEEP)
+	button.add_theme_color_override("font_disabled_color", COLOR_TEXT_DEEP)
+	button.add_theme_font_size_override("font_size", 26)
+	button.focus_mode = Control.FOCUS_NONE
+
+func _apply_primary_button_theme(button: Button) -> void:
+	var normal := StyleBoxFlat.new()
+	normal.bg_color = COLOR_MOSS
+	normal.border_color = Color("#3F5532")
+	normal.set_border_width_all(4)
+	normal.set_corner_radius_all(28)
+	normal.shadow_color = Color(0.10, 0.16, 0.08, 0.55)
+	normal.shadow_size = 8
+	normal.shadow_offset = Vector2(0, 5)
+
+	var hover := normal.duplicate() as StyleBoxFlat
+	hover.bg_color = Color("#74905D")
+
+	var pressed := normal.duplicate() as StyleBoxFlat
+	pressed.bg_color = Color("#506840")
+	pressed.shadow_offset = Vector2(0, 2)
+
+	var disabled := normal.duplicate() as StyleBoxFlat
+	disabled.bg_color = Color("#9CAB8B")
+
+	button.add_theme_stylebox_override("normal", normal)
+	button.add_theme_stylebox_override("hover", hover)
+	button.add_theme_stylebox_override("pressed", pressed)
+	button.add_theme_stylebox_override("disabled", disabled)
+	button.add_theme_color_override("font_color", COLOR_CREAM)
+	button.add_theme_color_override("font_hover_color", COLOR_CREAM_SOFT)
+	button.add_theme_color_override("font_pressed_color", COLOR_CREAM)
+	button.add_theme_color_override("font_disabled_color", COLOR_CREAM)
+	button.add_theme_font_size_override("font_size", 30)
+	button.focus_mode = Control.FOCUS_NONE
 
 func _on_seed_selected(seed_id: String) -> void:
 	selected_seed_id = seed_id
@@ -225,7 +374,7 @@ func _on_herb_bed_pressed() -> void:
 
 func _on_relationship_discovered(discovery: Dictionary) -> void:
 	status_panel.show_discovery(discovery)
-	_update_goal_label()
+	_update_goal_display()
 	_check_starter_goal()
 
 func _on_garden_message(message: String) -> void:
@@ -233,8 +382,8 @@ func _on_garden_message(message: String) -> void:
 
 func _on_harvest_completed(harvest_result: Dictionary) -> void:
 	total_harvest += harvest_result.get("yield_amount", 0)
-	harvest_label.text = "Harvest Basket: %s" % total_harvest
-	_update_goal_label()
+	harvest_value_label.text = "%s" % total_harvest
+	_update_goal_display()
 	_check_starter_goal()
 
 func _on_active_bed_changed(bed: GardenBed) -> void:
@@ -242,13 +391,22 @@ func _on_active_bed_changed(bed: GardenBed) -> void:
 	starter_bed_button.disabled = bed.bed_id == "starter_bed"
 	herb_bed_button.disabled = bed.bed_id == "herb_bed" or not herb_bed_unlocked
 
-func _update_goal_label() -> void:
-	goal_label.text = "Goal: %s/%s baskets  |  %s/%s discoveries" % [
-		min(total_harvest, TARGET_HARVEST),
+func _update_goal_display() -> void:
+	var discoveries := status_panel.get_diary_entry_count() if status_panel != null else 0
+	var harvest_clamped := min(total_harvest, TARGET_HARVEST)
+	var discoveries_clamped := min(discoveries, TARGET_DISCOVERIES)
+
+	goal_progress_label.text = "Goal:  %s/%s baskets    %s/%s discoveries" % [
+		harvest_clamped,
 		TARGET_HARVEST,
-		min(status_panel.get_diary_entry_count() if status_panel != null else 0, TARGET_DISCOVERIES),
+		discoveries_clamped,
 		TARGET_DISCOVERIES
 	]
+
+	if harvest_progress_bar != null:
+		harvest_progress_bar.value = harvest_clamped
+	if discovery_progress_bar != null:
+		discovery_progress_bar.value = discoveries_clamped
 
 func _check_starter_goal() -> void:
 	if starter_goal_completed:
@@ -262,6 +420,6 @@ func _check_starter_goal() -> void:
 
 	starter_goal_completed = true
 	herb_bed_unlocked = true
-	herb_bed_button.text = "Herb Bed"
+	herb_bed_button.text = "Herb"
 	herb_bed_button.disabled = false
 	status_panel.show_message("Starter Bed complete!\nHerb Bed unlocked.")

--- a/scripts/main_scene.gd
+++ b/scripts/main_scene.gd
@@ -392,9 +392,9 @@ func _on_active_bed_changed(bed: GardenBed) -> void:
 	herb_bed_button.disabled = bed.bed_id == "herb_bed" or not herb_bed_unlocked
 
 func _update_goal_display() -> void:
-	var discoveries := status_panel.get_diary_entry_count() if status_panel != null else 0
-	var harvest_clamped := min(total_harvest, TARGET_HARVEST)
-	var discoveries_clamped := min(discoveries, TARGET_DISCOVERIES)
+	var discoveries: int = status_panel.get_diary_entry_count() if status_panel != null else 0
+	var harvest_clamped: int = min(total_harvest, TARGET_HARVEST)
+	var discoveries_clamped: int = min(discoveries, TARGET_DISCOVERIES)
 
 	goal_progress_label.text = "Goal:  %s/%s baskets    %s/%s discoveries" % [
 		harvest_clamped,

--- a/scripts/ui/garden_status_panel.gd
+++ b/scripts/ui/garden_status_panel.gd
@@ -5,17 +5,47 @@ const TEXT_DEEP := Color("#263D25")
 const TEXT_SOFT := Color("#4A5C42")
 const ACCENT_SOIL := Color("#7B5738")
 const PAPER_CREAM := Color("#FBF4DD")
+const PAPER_WARM := Color("#FFF4D5")
 const SHADOW_INK := Color(0.10, 0.16, 0.08, 0.35)
+
+const COLOR_TYPE_GOOD := Color("#7B9B5A")
+const COLOR_TYPE_RISKY := Color("#B86F4B")
+const COLOR_TYPE_SPECIAL := Color("#C9A445")
+const COLOR_TYPE_NEUTRAL := Color("#8C9BC8")
 
 const STATUS_FADE_DELAY := 4.5
 const STATUS_FADE_DURATION := 0.6
 
+const DIARY_CARD_SIZE := Vector2(920, 1100)
+const PLANT_TILE_BG := Color("#FFF4D5")
+const PLANT_TILE_BORDER := Color("#D8BF83")
+
 var status_label: Label
+
+var diary_entries: Array[Dictionary] = []
 var diary_overlay: Control
 var diary_card: Panel
-var diary_label: Label
 var diary_heading: Label
-var diary_entries: Array[String] = []
+
+var list_view: Control
+var list_scroll: ScrollContainer
+var list_box: VBoxContainer
+var list_empty_label: Label
+var list_close_button: Button
+
+var detail_view: Control
+var detail_back_button: Button
+var detail_plant_a_panel: Panel
+var detail_plant_a_image: TextureRect
+var detail_plant_a_name: Label
+var detail_plant_b_panel: Panel
+var detail_plant_b_image: TextureRect
+var detail_plant_b_name: Label
+var detail_type_panel: Panel
+var detail_type_label: Label
+var detail_title_label: Label
+var detail_explanation_label: Label
+
 var status_tween: Tween
 var status_timer: float = 0.0
 var status_visible: bool = false
@@ -45,26 +75,39 @@ func show_discovery(discovery: Dictionary) -> void:
 	var first_name := PlantData.get_display_name(discovery.get("first_plant_id", ""))
 	var second_name := PlantData.get_display_name(discovery.get("second_plant_id", ""))
 	var short_reason: String = discovery.get("short_reason", discovery.get("explanation", ""))
-	var type_label := PlantRelationshipData.get_type_label(discovery.get("type", PlantRelationshipData.TYPE_NEUTRAL))
 
 	show_message("%s + %s — %s" % [first_name, second_name, short_reason])
-	add_diary_entry("%s: %s + %s" % [type_label, first_name, second_name])
+	add_diary_entry(discovery)
 
-func add_diary_entry(entry: String) -> void:
-	if diary_entries.has(entry):
-		return
+func add_diary_entry(discovery: Dictionary) -> void:
+	var key: String = discovery.get("key", PlantRelationshipData.get_relationship_key(
+		discovery.get("first_plant_id", ""),
+		discovery.get("second_plant_id", "")
+	))
 
-	diary_entries.append(entry)
-	_refresh_diary()
+	for existing in diary_entries:
+		if existing.get("key", "") == key:
+			return
+
+	var stored := discovery.duplicate()
+	stored["key"] = key
+	diary_entries.append(stored)
+	_refresh_diary_list()
 
 func get_diary_entry_count() -> int:
 	return diary_entries.size()
 
 func toggle_diary() -> void:
 	_build_ui()
-	diary_overlay.visible = not diary_overlay.visible
 	if diary_overlay.visible:
-		_refresh_diary()
+		close_diary()
+	else:
+		open_diary()
+
+func open_diary() -> void:
+	_build_ui()
+	_show_list_view()
+	diary_overlay.visible = true
 
 func close_diary() -> void:
 	_build_ui()
@@ -139,7 +182,7 @@ func _build_diary_overlay() -> void:
 	diary_card = _make_card(PAPER_CREAM, ACCENT_SOIL, 32, 4)
 	diary_card.name = "DiaryCard"
 	diary_card.position = Vector2(80, 380)
-	diary_card.size = Vector2(920, 1100)
+	diary_card.size = DIARY_CARD_SIZE
 	diary_overlay.add_child(diary_card)
 
 	diary_heading = Label.new()
@@ -159,43 +202,352 @@ func _build_diary_overlay() -> void:
 	separator.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	diary_card.add_child(separator)
 
-	diary_label = Label.new()
-	diary_label.name = "DiaryLabel"
-	diary_label.position = Vector2(40, 110)
-	diary_label.size = Vector2(840, 880)
-	diary_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	diary_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
-	diary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	diary_label.add_theme_color_override("font_color", TEXT_SOFT)
-	diary_label.add_theme_font_size_override("font_size", 24)
-	diary_card.add_child(diary_label)
+	_build_list_view()
+	_build_detail_view()
+	_show_list_view()
 
-	var close_button := Button.new()
-	close_button.name = "DiaryCloseButton"
-	close_button.text = "Close"
-	close_button.position = Vector2(360, 1010)
-	close_button.size = Vector2(200, 70)
-	close_button.focus_mode = Control.FOCUS_NONE
-	_apply_close_theme(close_button)
-	close_button.pressed.connect(close_diary)
-	diary_card.add_child(close_button)
+func _build_list_view() -> void:
+	list_view = Control.new()
+	list_view.name = "DiaryListView"
+	list_view.position = Vector2(0, 100)
+	list_view.size = Vector2(DIARY_CARD_SIZE.x, DIARY_CARD_SIZE.y - 100)
+	diary_card.add_child(list_view)
 
-func _refresh_diary() -> void:
-	if diary_label == null:
+	list_scroll = ScrollContainer.new()
+	list_scroll.name = "DiaryListScroll"
+	list_scroll.position = Vector2(28, 12)
+	list_scroll.size = Vector2(DIARY_CARD_SIZE.x - 56, list_view.size.y - 110)
+	list_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	list_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+	list_scroll.scroll_deadzone = 12
+	list_view.add_child(list_scroll)
+
+	list_box = VBoxContainer.new()
+	list_box.name = "DiaryListBox"
+	list_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	list_box.add_theme_constant_override("separation", 14)
+	list_scroll.add_child(list_box)
+
+	list_empty_label = Label.new()
+	list_empty_label.name = "DiaryEmptyLabel"
+	list_empty_label.text = "Plant neighbors and discover how they get along.\nYour first findings will appear here."
+	list_empty_label.position = Vector2(40, 80)
+	list_empty_label.size = Vector2(DIARY_CARD_SIZE.x - 80, 200)
+	list_empty_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	list_empty_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
+	list_empty_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	list_empty_label.add_theme_color_override("font_color", TEXT_SOFT)
+	list_empty_label.add_theme_font_size_override("font_size", 24)
+	list_view.add_child(list_empty_label)
+
+	list_close_button = Button.new()
+	list_close_button.name = "DiaryCloseButton"
+	list_close_button.text = "Close"
+	list_close_button.position = Vector2((DIARY_CARD_SIZE.x - 200) / 2.0, list_view.size.y - 90)
+	list_close_button.size = Vector2(200, 70)
+	list_close_button.focus_mode = Control.FOCUS_NONE
+	_apply_pill_button_theme(list_close_button, Color("#627A4E"), Color("#3F5532"), PAPER_CREAM)
+	list_close_button.pressed.connect(close_diary)
+	list_view.add_child(list_close_button)
+
+func _build_detail_view() -> void:
+	detail_view = Control.new()
+	detail_view.name = "DiaryDetailView"
+	detail_view.position = Vector2(0, 0)
+	detail_view.size = DIARY_CARD_SIZE
+	detail_view.visible = false
+	diary_card.add_child(detail_view)
+
+	detail_back_button = Button.new()
+	detail_back_button.name = "DiaryBackButton"
+	detail_back_button.text = "< Back"
+	detail_back_button.position = Vector2(28, 28)
+	detail_back_button.size = Vector2(150, 60)
+	detail_back_button.focus_mode = Control.FOCUS_NONE
+	_apply_pill_button_theme(detail_back_button, PAPER_WARM, ACCENT_SOIL, TEXT_DEEP)
+	detail_back_button.pressed.connect(_show_list_view)
+	detail_view.add_child(detail_back_button)
+
+	var plant_tile_size := Vector2(340, 340)
+	var plant_a_origin := Vector2(80, 130)
+	var plant_b_origin := Vector2(500, 130)
+
+	detail_plant_a_panel = _make_plant_tile()
+	detail_plant_a_panel.position = plant_a_origin
+	detail_plant_a_panel.size = plant_tile_size
+	detail_view.add_child(detail_plant_a_panel)
+
+	detail_plant_a_image = TextureRect.new()
+	detail_plant_a_image.name = "PlantAImage"
+	detail_plant_a_image.position = Vector2(30, 30)
+	detail_plant_a_image.size = Vector2(280, 230)
+	detail_plant_a_image.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	detail_plant_a_image.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	detail_plant_a_image.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	detail_plant_a_panel.add_child(detail_plant_a_image)
+
+	detail_plant_a_name = Label.new()
+	detail_plant_a_name.name = "PlantAName"
+	detail_plant_a_name.position = Vector2(0, 270)
+	detail_plant_a_name.size = Vector2(plant_tile_size.x, 50)
+	detail_plant_a_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	detail_plant_a_name.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	detail_plant_a_name.add_theme_color_override("font_color", TEXT_DEEP)
+	detail_plant_a_name.add_theme_font_size_override("font_size", 26)
+	detail_plant_a_panel.add_child(detail_plant_a_name)
+
+	var plus_label := Label.new()
+	plus_label.name = "PlusLabel"
+	plus_label.text = "+"
+	plus_label.position = Vector2(plant_a_origin.x + plant_tile_size.x, plant_a_origin.y)
+	plus_label.size = Vector2(plant_b_origin.x - plant_a_origin.x - plant_tile_size.x, plant_tile_size.y)
+	plus_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	plus_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	plus_label.add_theme_color_override("font_color", ACCENT_SOIL)
+	plus_label.add_theme_font_size_override("font_size", 64)
+	detail_view.add_child(plus_label)
+
+	detail_plant_b_panel = _make_plant_tile()
+	detail_plant_b_panel.position = plant_b_origin
+	detail_plant_b_panel.size = plant_tile_size
+	detail_view.add_child(detail_plant_b_panel)
+
+	detail_plant_b_image = TextureRect.new()
+	detail_plant_b_image.name = "PlantBImage"
+	detail_plant_b_image.position = Vector2(30, 30)
+	detail_plant_b_image.size = Vector2(280, 230)
+	detail_plant_b_image.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	detail_plant_b_image.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	detail_plant_b_image.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	detail_plant_b_panel.add_child(detail_plant_b_image)
+
+	detail_plant_b_name = Label.new()
+	detail_plant_b_name.name = "PlantBName"
+	detail_plant_b_name.position = Vector2(0, 270)
+	detail_plant_b_name.size = Vector2(plant_tile_size.x, 50)
+	detail_plant_b_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	detail_plant_b_name.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	detail_plant_b_name.add_theme_color_override("font_color", TEXT_DEEP)
+	detail_plant_b_name.add_theme_font_size_override("font_size", 26)
+	detail_plant_b_panel.add_child(detail_plant_b_name)
+
+	detail_type_panel = Panel.new()
+	detail_type_panel.position = Vector2((DIARY_CARD_SIZE.x - 240) / 2.0, 510)
+	detail_type_panel.size = Vector2(240, 56)
+	detail_view.add_child(detail_type_panel)
+
+	detail_type_label = Label.new()
+	detail_type_label.name = "DetailTypeLabel"
+	detail_type_label.position = Vector2(0, 0)
+	detail_type_label.size = detail_type_panel.size
+	detail_type_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	detail_type_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	detail_type_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	detail_type_label.add_theme_color_override("font_color", PAPER_CREAM)
+	detail_type_label.add_theme_font_size_override("font_size", 22)
+	detail_type_panel.add_child(detail_type_label)
+
+	detail_title_label = Label.new()
+	detail_title_label.name = "DetailTitle"
+	detail_title_label.position = Vector2(60, 600)
+	detail_title_label.size = Vector2(DIARY_CARD_SIZE.x - 120, 60)
+	detail_title_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	detail_title_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	detail_title_label.add_theme_color_override("font_color", TEXT_DEEP)
+	detail_title_label.add_theme_font_size_override("font_size", 30)
+	detail_view.add_child(detail_title_label)
+
+	detail_explanation_label = Label.new()
+	detail_explanation_label.name = "DetailExplanation"
+	detail_explanation_label.position = Vector2(60, 670)
+	detail_explanation_label.size = Vector2(DIARY_CARD_SIZE.x - 120, DIARY_CARD_SIZE.y - 700)
+	detail_explanation_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	detail_explanation_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
+	detail_explanation_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	detail_explanation_label.add_theme_color_override("font_color", TEXT_SOFT)
+	detail_explanation_label.add_theme_font_size_override("font_size", 22)
+	detail_view.add_child(detail_explanation_label)
+
+func _show_list_view() -> void:
+	if list_view == null:
 		return
+
+	list_view.visible = true
+	if detail_view != null:
+		detail_view.visible = false
+	_refresh_diary_list()
+
+func _show_detail_view(entry: Dictionary) -> void:
+	if detail_view == null:
+		return
+
+	list_view.visible = false
+	detail_view.visible = true
+
+	var first_id: String = entry.get("first_plant_id", "")
+	var second_id: String = entry.get("second_plant_id", "")
+	var type_id: String = entry.get("type", PlantRelationshipData.TYPE_NEUTRAL)
+
+	detail_plant_a_name.text = PlantData.get_display_name(first_id)
+	detail_plant_b_name.text = PlantData.get_display_name(second_id)
+	_set_plant_tile_image(detail_plant_a_image, first_id)
+	_set_plant_tile_image(detail_plant_b_image, second_id)
+
+	detail_type_label.text = PlantRelationshipData.get_type_label(type_id)
+	_apply_type_panel_color(detail_type_panel, type_id)
+
+	detail_title_label.text = entry.get("title", "")
+	detail_explanation_label.text = entry.get("explanation", entry.get("short_reason", ""))
+
+func _refresh_diary_list() -> void:
+	if list_box == null:
+		return
+
+	for child in list_box.get_children():
+		child.queue_free()
 
 	if diary_entries.is_empty():
 		diary_heading.text = "Garden Diary"
-		diary_label.text = "Plant neighbors and discover how they get along.\nYour first findings will appear here."
+		list_empty_label.visible = true
 		return
 
 	diary_heading.text = "Garden Diary  (%s)" % diary_entries.size()
-	var diary_text := ""
+	list_empty_label.visible = false
+
 	for entry in diary_entries:
-		if not diary_text.is_empty():
-			diary_text += "\n"
-		diary_text += "•  %s" % entry
-	diary_label.text = diary_text
+		list_box.add_child(_make_entry_button(entry))
+
+func _make_entry_button(entry: Dictionary) -> Button:
+	var button := Button.new()
+	button.custom_minimum_size = Vector2(0, 96)
+	button.focus_mode = Control.FOCUS_NONE
+	button.flat = true
+	button.pressed.connect(_show_detail_view.bind(entry))
+
+	var card_style := StyleBoxFlat.new()
+	card_style.bg_color = PAPER_WARM
+	card_style.border_color = Color(ACCENT_SOIL.r, ACCENT_SOIL.g, ACCENT_SOIL.b, 0.5)
+	card_style.set_border_width_all(2)
+	card_style.set_corner_radius_all(20)
+
+	var hover_style := card_style.duplicate() as StyleBoxFlat
+	hover_style.bg_color = Color("#FFE9B5")
+
+	var pressed_style := card_style.duplicate() as StyleBoxFlat
+	pressed_style.bg_color = Color("#F4DDA4")
+
+	button.add_theme_stylebox_override("normal", card_style)
+	button.add_theme_stylebox_override("hover", hover_style)
+	button.add_theme_stylebox_override("pressed", pressed_style)
+	button.add_theme_color_override("font_color", Color(0, 0, 0, 0))
+	button.add_theme_color_override("font_hover_color", Color(0, 0, 0, 0))
+	button.add_theme_color_override("font_pressed_color", Color(0, 0, 0, 0))
+
+	var type_id: String = entry.get("type", PlantRelationshipData.TYPE_NEUTRAL)
+
+	var type_panel := Panel.new()
+	type_panel.name = "TypeBadge"
+	type_panel.position = Vector2(20, 20)
+	type_panel.size = Vector2(150, 56)
+	type_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_apply_type_panel_color(type_panel, type_id)
+	button.add_child(type_panel)
+
+	var type_label := Label.new()
+	type_label.name = "TypeLabel"
+	type_label.text = PlantRelationshipData.get_type_label(type_id)
+	type_label.position = Vector2(0, 0)
+	type_label.size = type_panel.size
+	type_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	type_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	type_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	type_label.add_theme_color_override("font_color", PAPER_CREAM)
+	type_label.add_theme_font_size_override("font_size", 20)
+	type_panel.add_child(type_label)
+
+	var first_name := PlantData.get_display_name(entry.get("first_plant_id", ""))
+	var second_name := PlantData.get_display_name(entry.get("second_plant_id", ""))
+
+	var pair_label := Label.new()
+	pair_label.name = "PairLabel"
+	pair_label.text = "%s  +  %s" % [first_name, second_name]
+	pair_label.position = Vector2(190, 18)
+	pair_label.size = Vector2(540, 36)
+	pair_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	pair_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	pair_label.add_theme_color_override("font_color", TEXT_DEEP)
+	pair_label.add_theme_font_size_override("font_size", 26)
+	button.add_child(pair_label)
+
+	var subtitle: String = entry.get("title", "")
+	var subtitle_label := Label.new()
+	subtitle_label.name = "SubtitleLabel"
+	subtitle_label.text = subtitle
+	subtitle_label.position = Vector2(190, 54)
+	subtitle_label.size = Vector2(540, 32)
+	subtitle_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	subtitle_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	subtitle_label.add_theme_color_override("font_color", TEXT_SOFT)
+	subtitle_label.add_theme_font_size_override("font_size", 20)
+	button.add_child(subtitle_label)
+
+	var arrow_label := Label.new()
+	arrow_label.name = "ArrowLabel"
+	arrow_label.text = ">"
+	arrow_label.position = Vector2(740, 0)
+	arrow_label.size = Vector2(60, 96)
+	arrow_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	arrow_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	arrow_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	arrow_label.add_theme_color_override("font_color", ACCENT_SOIL)
+	arrow_label.add_theme_font_size_override("font_size", 32)
+	button.add_child(arrow_label)
+
+	return button
+
+func _make_plant_tile() -> Panel:
+	var panel := Panel.new()
+	var style := StyleBoxFlat.new()
+	style.bg_color = PLANT_TILE_BG
+	style.border_color = PLANT_TILE_BORDER
+	style.set_border_width_all(3)
+	style.set_corner_radius_all(28)
+	style.shadow_color = SHADOW_INK
+	style.shadow_size = 6
+	style.shadow_offset = Vector2(0, 4)
+	panel.add_theme_stylebox_override("panel", style)
+	return panel
+
+func _set_plant_tile_image(image: TextureRect, plant_id: String) -> void:
+	if image == null:
+		return
+
+	var sprite_path := PlantData.get_stage_sprite_path(plant_id, 1)
+	if sprite_path.is_empty() or not ResourceLoader.exists(sprite_path):
+		image.texture = null
+		return
+
+	image.texture = load(sprite_path)
+
+func _apply_type_panel_color(panel: Panel, type_id: String) -> void:
+	var color := _color_for_type(type_id)
+	var style := StyleBoxFlat.new()
+	style.bg_color = color
+	style.border_color = Color(color.r * 0.7, color.g * 0.7, color.b * 0.7)
+	style.set_border_width_all(2)
+	style.set_corner_radius_all(20)
+	panel.add_theme_stylebox_override("panel", style)
+
+func _color_for_type(type_id: String) -> Color:
+	match type_id:
+		PlantRelationshipData.TYPE_GOOD:
+			return COLOR_TYPE_GOOD
+		PlantRelationshipData.TYPE_RISKY:
+			return COLOR_TYPE_RISKY
+		PlantRelationshipData.TYPE_SPECIAL:
+			return COLOR_TYPE_SPECIAL
+		_:
+			return COLOR_TYPE_NEUTRAL
 
 func _make_card(bg: Color, border: Color, radius: int, border_width: int) -> Panel:
 	var panel := Panel.new()
@@ -210,23 +562,23 @@ func _make_card(bg: Color, border: Color, radius: int, border_width: int) -> Pan
 	panel.add_theme_stylebox_override("panel", style)
 	return panel
 
-func _apply_close_theme(button: Button) -> void:
+func _apply_pill_button_theme(button: Button, bg: Color, border: Color, font_color: Color) -> void:
 	var normal := StyleBoxFlat.new()
-	normal.bg_color = Color("#627A4E")
-	normal.border_color = Color("#3F5532")
+	normal.bg_color = bg
+	normal.border_color = border
 	normal.set_border_width_all(3)
 	normal.set_corner_radius_all(20)
 
 	var hover := normal.duplicate() as StyleBoxFlat
-	hover.bg_color = Color("#74905D")
+	hover.bg_color = Color(bg.r * 0.95, bg.g * 0.95, bg.b * 0.95)
 
 	var pressed := normal.duplicate() as StyleBoxFlat
-	pressed.bg_color = Color("#506840")
+	pressed.bg_color = Color(bg.r * 0.88, bg.g * 0.88, bg.b * 0.88)
 
 	button.add_theme_stylebox_override("normal", normal)
 	button.add_theme_stylebox_override("hover", hover)
 	button.add_theme_stylebox_override("pressed", pressed)
-	button.add_theme_color_override("font_color", PAPER_CREAM)
-	button.add_theme_color_override("font_hover_color", PAPER_CREAM)
-	button.add_theme_color_override("font_pressed_color", PAPER_CREAM)
+	button.add_theme_color_override("font_color", font_color)
+	button.add_theme_color_override("font_hover_color", font_color)
+	button.add_theme_color_override("font_pressed_color", font_color)
 	button.add_theme_font_size_override("font_size", 24)

--- a/scripts/ui/garden_status_panel.gd
+++ b/scripts/ui/garden_status_panel.gd
@@ -1,9 +1,21 @@
 class_name GardenStatusPanel
 extends Control
 
-const TEXT_COLOR := Color(0.16, 0.24, 0.14)
+const TEXT_DEEP := Color("#263D25")
+const TEXT_SOFT := Color("#4A5C42")
+const ACCENT_SOIL := Color("#7B5738")
+const PAPER_CREAM := Color("#FBF4DD")
+const SHADOW_INK := Color(0.10, 0.16, 0.08, 0.35)
 
+const PANEL_WIDTH := 968
+const PANEL_HEIGHT := 280
+const STATUS_HEIGHT := 110
+const SEPARATOR_THICKNESS := 2
+
+var status_card: Panel
 var status_label: Label
+var diary_card: Panel
+var diary_heading: Label
 var diary_label: Label
 var diary_entries: Array[String] = []
 
@@ -43,41 +55,87 @@ func _build_ui() -> void:
 	if status_label != null:
 		return
 
-	size = Vector2(1080, 285)
+	size = Vector2(PANEL_WIDTH, PANEL_HEIGHT)
+
+	status_card = _make_card(Color("#FFFAE3"), ACCENT_SOIL, 22, 3)
+	status_card.name = "StatusCard"
+	status_card.position = Vector2(0, 0)
+	status_card.size = Vector2(PANEL_WIDTH, STATUS_HEIGHT)
+	add_child(status_card)
 
 	status_label = Label.new()
 	status_label.name = "StatusLabel"
-	status_label.position = Vector2(110, 0)
-	status_label.size = Vector2(860, 110)
+	status_label.position = Vector2(28, 12)
+	status_label.size = Vector2(PANEL_WIDTH - 56, STATUS_HEIGHT - 24)
 	status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	status_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	status_label.add_theme_color_override("font_color", TEXT_COLOR)
-	status_label.add_theme_font_size_override("font_size", 24)
-	add_child(status_label)
+	status_label.add_theme_color_override("font_color", TEXT_DEEP)
+	status_label.add_theme_font_size_override("font_size", 22)
+	status_card.add_child(status_label)
+
+	diary_card = _make_card(PAPER_CREAM, ACCENT_SOIL, 22, 3)
+	diary_card.name = "DiaryCard"
+	diary_card.position = Vector2(0, STATUS_HEIGHT + 14)
+	diary_card.size = Vector2(PANEL_WIDTH, PANEL_HEIGHT - STATUS_HEIGHT - 14)
+	add_child(diary_card)
+
+	diary_heading = Label.new()
+	diary_heading.name = "DiaryHeading"
+	diary_heading.text = "Garden Diary"
+	diary_heading.position = Vector2(28, 10)
+	diary_heading.size = Vector2(PANEL_WIDTH - 56, 30)
+	diary_heading.add_theme_color_override("font_color", TEXT_DEEP)
+	diary_heading.add_theme_font_size_override("font_size", 22)
+	diary_card.add_child(diary_heading)
+
+	var separator := ColorRect.new()
+	separator.name = "DiarySeparator"
+	separator.color = Color(ACCENT_SOIL.r, ACCENT_SOIL.g, ACCENT_SOIL.b, 0.45)
+	separator.position = Vector2(28, 44)
+	separator.size = Vector2(PANEL_WIDTH - 56, SEPARATOR_THICKNESS)
+	separator.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	diary_card.add_child(separator)
 
 	diary_label = Label.new()
 	diary_label.name = "DiaryLabel"
-	diary_label.position = Vector2(110, 120)
-	diary_label.size = Vector2(860, 165)
-	diary_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	diary_label.position = Vector2(28, 54)
+	diary_label.size = Vector2(PANEL_WIDTH - 56, diary_card.size.y - 64)
+	diary_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
 	diary_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
 	diary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	diary_label.add_theme_color_override("font_color", TEXT_COLOR)
-	diary_label.add_theme_font_size_override("font_size", 21)
-	add_child(diary_label)
+	diary_label.add_theme_color_override("font_color", TEXT_SOFT)
+	diary_label.add_theme_font_size_override("font_size", 20)
+	diary_card.add_child(diary_label)
+
+func _make_card(bg: Color, border: Color, radius: int, border_width: int) -> Panel:
+	var panel := Panel.new()
+	var style := StyleBoxFlat.new()
+	style.bg_color = bg
+	style.border_color = border
+	style.set_border_width_all(border_width)
+	style.set_corner_radius_all(radius)
+	style.shadow_color = SHADOW_INK
+	style.shadow_size = 4
+	style.shadow_offset = Vector2(0, 3)
+	panel.add_theme_stylebox_override("panel", style)
+	return panel
 
 func _update_diary_label() -> void:
 	_build_ui()
 
 	if diary_entries.is_empty():
-		diary_label.text = "Garden Diary\nNo plant relationships discovered yet."
+		diary_heading.text = "Garden Diary"
+		diary_label.text = "No plant relationships discovered yet."
 		return
 
-	var diary_text := "Garden Diary (%s)" % diary_entries.size()
+	diary_heading.text = "Garden Diary  (%s)" % diary_entries.size()
+	var diary_text := ""
 	var start_index: int = max(diary_entries.size() - 4, 0)
 
 	for index in range(start_index, diary_entries.size()):
-		diary_text += "\n- %s" % diary_entries[index]
+		if not diary_text.is_empty():
+			diary_text += "\n"
+		diary_text += "•  %s" % diary_entries[index]
 
 	diary_label.text = diary_text

--- a/scripts/ui/garden_status_panel.gd
+++ b/scripts/ui/garden_status_panel.gd
@@ -7,38 +7,47 @@ const ACCENT_SOIL := Color("#7B5738")
 const PAPER_CREAM := Color("#FBF4DD")
 const SHADOW_INK := Color(0.10, 0.16, 0.08, 0.35)
 
-const PANEL_WIDTH := 968
-const PANEL_HEIGHT := 280
-const STATUS_HEIGHT := 110
-const SEPARATOR_THICKNESS := 2
+const STATUS_FADE_DELAY := 4.5
+const STATUS_FADE_DURATION := 0.6
 
-var status_card: Panel
 var status_label: Label
+var diary_overlay: Control
 var diary_card: Panel
-var diary_heading: Label
 var diary_label: Label
+var diary_heading: Label
 var diary_entries: Array[String] = []
+var status_tween: Tween
+var status_timer: float = 0.0
+var status_visible: bool = false
 
 func _ready() -> void:
 	_build_ui()
+	set_process(true)
 
 func setup() -> void:
 	_build_ui()
-	show_message("Plant neighbors, water the garden, then tap mature plants to harvest.")
-	_update_diary_label()
+	show_message("Tap a bed to plant. Water to grow.")
 
 func show_message(message: String) -> void:
 	_build_ui()
+	if message.is_empty():
+		return
+
 	status_label.text = message
+	status_label.modulate.a = 1.0
+	status_visible = true
+	status_timer = 0.0
+
+	if status_tween != null and status_tween.is_valid():
+		status_tween.kill()
 
 func show_discovery(discovery: Dictionary) -> void:
 	var first_name := PlantData.get_display_name(discovery.get("first_plant_id", ""))
 	var second_name := PlantData.get_display_name(discovery.get("second_plant_id", ""))
-	var type_label := PlantRelationshipData.get_type_label(discovery.get("type", PlantRelationshipData.TYPE_NEUTRAL))
-	var title: String = discovery.get("title", "New discovery")
 	var short_reason: String = discovery.get("short_reason", discovery.get("explanation", ""))
+	var type_label := PlantRelationshipData.get_type_label(discovery.get("type", PlantRelationshipData.TYPE_NEUTRAL))
 
-	show_message("New discovery: %s + %s\n%s: %s" % [first_name, second_name, title, short_reason])
+	show_message("%s + %s — %s" % [first_name, second_name, short_reason])
 	add_diary_entry("%s: %s + %s" % [type_label, first_name, second_name])
 
 func add_diary_entry(entry: String) -> void:
@@ -46,67 +55,147 @@ func add_diary_entry(entry: String) -> void:
 		return
 
 	diary_entries.append(entry)
-	_update_diary_label()
+	_refresh_diary()
 
 func get_diary_entry_count() -> int:
 	return diary_entries.size()
+
+func toggle_diary() -> void:
+	_build_ui()
+	diary_overlay.visible = not diary_overlay.visible
+	if diary_overlay.visible:
+		_refresh_diary()
+
+func close_diary() -> void:
+	_build_ui()
+	diary_overlay.visible = false
+
+func is_diary_open() -> bool:
+	return diary_overlay != null and diary_overlay.visible
+
+func _process(delta: float) -> void:
+	if not status_visible or status_label == null:
+		return
+
+	status_timer += delta
+	if status_timer < STATUS_FADE_DELAY:
+		return
+
+	status_visible = false
+	status_tween = create_tween()
+	status_tween.tween_property(status_label, "modulate:a", 0.0, STATUS_FADE_DURATION)
 
 func _build_ui() -> void:
 	if status_label != null:
 		return
 
-	size = Vector2(PANEL_WIDTH, PANEL_HEIGHT)
-
-	status_card = _make_card(Color("#FFFAE3"), ACCENT_SOIL, 22, 3)
-	status_card.name = "StatusCard"
-	status_card.position = Vector2(0, 0)
-	status_card.size = Vector2(PANEL_WIDTH, STATUS_HEIGHT)
-	add_child(status_card)
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(1080, 1920)
 
 	status_label = Label.new()
 	status_label.name = "StatusLabel"
-	status_label.position = Vector2(28, 12)
-	status_label.size = Vector2(PANEL_WIDTH - 56, STATUS_HEIGHT - 24)
+	status_label.position = Vector2(60, 0)
+	status_label.size = Vector2(960, 60)
 	status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	status_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	status_label.add_theme_color_override("font_color", TEXT_DEEP)
+	status_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	status_label.add_theme_color_override("font_color", TEXT_SOFT)
+	status_label.add_theme_color_override("font_shadow_color", Color(1.0, 1.0, 0.92, 0.85))
+	status_label.add_theme_constant_override("shadow_offset_x", 0)
+	status_label.add_theme_constant_override("shadow_offset_y", 1)
 	status_label.add_theme_font_size_override("font_size", 22)
-	status_card.add_child(status_label)
+	status_label.modulate.a = 0.0
+	add_child(status_label)
 
-	diary_card = _make_card(PAPER_CREAM, ACCENT_SOIL, 22, 3)
+	_build_diary_overlay()
+
+func _build_diary_overlay() -> void:
+	diary_overlay = Control.new()
+	diary_overlay.name = "DiaryOverlay"
+	diary_overlay.position = Vector2.ZERO
+	diary_overlay.size = Vector2(1080, 1920)
+	diary_overlay.visible = false
+	diary_overlay.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(diary_overlay)
+
+	var dim := ColorRect.new()
+	dim.name = "DiaryDim"
+	dim.color = Color(0.10, 0.14, 0.08, 0.55)
+	dim.position = Vector2.ZERO
+	dim.size = Vector2(1080, 1920)
+	dim.mouse_filter = Control.MOUSE_FILTER_STOP
+	diary_overlay.add_child(dim)
+
+	var dim_button := Button.new()
+	dim_button.name = "DiaryDimButton"
+	dim_button.flat = true
+	dim_button.position = Vector2.ZERO
+	dim_button.size = Vector2(1080, 1920)
+	dim_button.focus_mode = Control.FOCUS_NONE
+	dim_button.pressed.connect(close_diary)
+	diary_overlay.add_child(dim_button)
+
+	diary_card = _make_card(PAPER_CREAM, ACCENT_SOIL, 32, 4)
 	diary_card.name = "DiaryCard"
-	diary_card.position = Vector2(0, STATUS_HEIGHT + 14)
-	diary_card.size = Vector2(PANEL_WIDTH, PANEL_HEIGHT - STATUS_HEIGHT - 14)
-	add_child(diary_card)
+	diary_card.position = Vector2(80, 380)
+	diary_card.size = Vector2(920, 1100)
+	diary_overlay.add_child(diary_card)
 
 	diary_heading = Label.new()
 	diary_heading.name = "DiaryHeading"
 	diary_heading.text = "Garden Diary"
-	diary_heading.position = Vector2(28, 10)
-	diary_heading.size = Vector2(PANEL_WIDTH - 56, 30)
+	diary_heading.position = Vector2(40, 32)
+	diary_heading.size = Vector2(840, 48)
 	diary_heading.add_theme_color_override("font_color", TEXT_DEEP)
-	diary_heading.add_theme_font_size_override("font_size", 22)
+	diary_heading.add_theme_font_size_override("font_size", 32)
 	diary_card.add_child(diary_heading)
 
 	var separator := ColorRect.new()
 	separator.name = "DiarySeparator"
-	separator.color = Color(ACCENT_SOIL.r, ACCENT_SOIL.g, ACCENT_SOIL.b, 0.45)
-	separator.position = Vector2(28, 44)
-	separator.size = Vector2(PANEL_WIDTH - 56, SEPARATOR_THICKNESS)
+	separator.color = Color(ACCENT_SOIL.r, ACCENT_SOIL.g, ACCENT_SOIL.b, 0.4)
+	separator.position = Vector2(40, 90)
+	separator.size = Vector2(840, 2)
 	separator.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	diary_card.add_child(separator)
 
 	diary_label = Label.new()
 	diary_label.name = "DiaryLabel"
-	diary_label.position = Vector2(28, 54)
-	diary_label.size = Vector2(PANEL_WIDTH - 56, diary_card.size.y - 64)
+	diary_label.position = Vector2(40, 110)
+	diary_label.size = Vector2(840, 880)
 	diary_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
 	diary_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
 	diary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	diary_label.add_theme_color_override("font_color", TEXT_SOFT)
-	diary_label.add_theme_font_size_override("font_size", 20)
+	diary_label.add_theme_font_size_override("font_size", 24)
 	diary_card.add_child(diary_label)
+
+	var close_button := Button.new()
+	close_button.name = "DiaryCloseButton"
+	close_button.text = "Close"
+	close_button.position = Vector2(360, 1010)
+	close_button.size = Vector2(200, 70)
+	close_button.focus_mode = Control.FOCUS_NONE
+	_apply_close_theme(close_button)
+	close_button.pressed.connect(close_diary)
+	diary_card.add_child(close_button)
+
+func _refresh_diary() -> void:
+	if diary_label == null:
+		return
+
+	if diary_entries.is_empty():
+		diary_heading.text = "Garden Diary"
+		diary_label.text = "Plant neighbors and discover how they get along.\nYour first findings will appear here."
+		return
+
+	diary_heading.text = "Garden Diary  (%s)" % diary_entries.size()
+	var diary_text := ""
+	for entry in diary_entries:
+		if not diary_text.is_empty():
+			diary_text += "\n"
+		diary_text += "•  %s" % entry
+	diary_label.text = diary_text
 
 func _make_card(bg: Color, border: Color, radius: int, border_width: int) -> Panel:
 	var panel := Panel.new()
@@ -116,26 +205,28 @@ func _make_card(bg: Color, border: Color, radius: int, border_width: int) -> Pan
 	style.set_border_width_all(border_width)
 	style.set_corner_radius_all(radius)
 	style.shadow_color = SHADOW_INK
-	style.shadow_size = 4
-	style.shadow_offset = Vector2(0, 3)
+	style.shadow_size = 8
+	style.shadow_offset = Vector2(0, 5)
 	panel.add_theme_stylebox_override("panel", style)
 	return panel
 
-func _update_diary_label() -> void:
-	_build_ui()
+func _apply_close_theme(button: Button) -> void:
+	var normal := StyleBoxFlat.new()
+	normal.bg_color = Color("#627A4E")
+	normal.border_color = Color("#3F5532")
+	normal.set_border_width_all(3)
+	normal.set_corner_radius_all(20)
 
-	if diary_entries.is_empty():
-		diary_heading.text = "Garden Diary"
-		diary_label.text = "No plant relationships discovered yet."
-		return
+	var hover := normal.duplicate() as StyleBoxFlat
+	hover.bg_color = Color("#74905D")
 
-	diary_heading.text = "Garden Diary  (%s)" % diary_entries.size()
-	var diary_text := ""
-	var start_index: int = max(diary_entries.size() - 4, 0)
+	var pressed := normal.duplicate() as StyleBoxFlat
+	pressed.bg_color = Color("#506840")
 
-	for index in range(start_index, diary_entries.size()):
-		if not diary_text.is_empty():
-			diary_text += "\n"
-		diary_text += "•  %s" % diary_entries[index]
-
-	diary_label.text = diary_text
+	button.add_theme_stylebox_override("normal", normal)
+	button.add_theme_stylebox_override("hover", hover)
+	button.add_theme_stylebox_override("pressed", pressed)
+	button.add_theme_color_override("font_color", PAPER_CREAM)
+	button.add_theme_color_override("font_hover_color", PAPER_CREAM)
+	button.add_theme_color_override("font_pressed_color", PAPER_CREAM)
+	button.add_theme_font_size_override("font_size", 24)

--- a/scripts/ui/seed_bar.gd
+++ b/scripts/ui/seed_bar.gd
@@ -3,13 +3,15 @@ extends Control
 
 signal seed_selected(seed_id: String)
 
-const TEXT_COLOR := Color(0.16, 0.24, 0.14)
+const TEXT_DEEP := Color("#263D25")
+const TEXT_SOFT := Color("#4A5C42")
 const SEED_SLOT_TEXTURE_PATH := "res://assets/ui/seed_bar/ui_seed_slot.svg"
 const SEED_SLOT_SELECTED_TEXTURE_PATH := "res://assets/ui/seed_bar/ui_seed_slot_selected.svg"
 
 var available_seeds: Array = []
 var selected_seed_id := "carrot"
 var seed_buttons: Dictionary = {}
+var heading_label: Label
 var selected_seed_label: Label
 var scroll_container: ScrollContainer
 var seed_container: HBoxContainer
@@ -28,24 +30,33 @@ func set_selected_seed(seed_id: String) -> void:
 	_update_selection_ui()
 
 func _build_ui() -> void:
-	if selected_seed_label != null:
+	if heading_label != null:
 		return
 
-	size = Vector2(1080, 205)
+	size = Vector2(968, 220)
+
+	heading_label = Label.new()
+	heading_label.name = "HeadingLabel"
+	heading_label.text = "Seeds"
+	heading_label.position = Vector2(0, 0)
+	heading_label.size = Vector2(300, 36)
+	heading_label.add_theme_color_override("font_color", TEXT_DEEP)
+	heading_label.add_theme_font_size_override("font_size", 24)
+	add_child(heading_label)
 
 	selected_seed_label = Label.new()
 	selected_seed_label.name = "SelectedSeedLabel"
-	selected_seed_label.position = Vector2(0, 0)
-	selected_seed_label.size = Vector2(1080, 50)
-	selected_seed_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	selected_seed_label.add_theme_color_override("font_color", TEXT_COLOR)
-	selected_seed_label.add_theme_font_size_override("font_size", 28)
+	selected_seed_label.position = Vector2(300, 0)
+	selected_seed_label.size = Vector2(668, 36)
+	selected_seed_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	selected_seed_label.add_theme_color_override("font_color", TEXT_SOFT)
+	selected_seed_label.add_theme_font_size_override("font_size", 22)
 	add_child(selected_seed_label)
 
 	scroll_container = ScrollContainer.new()
 	scroll_container.name = "SeedScrollContainer"
-	scroll_container.position = Vector2(44, 65)
-	scroll_container.size = Vector2(992, 140)
+	scroll_container.position = Vector2(0, 50)
+	scroll_container.size = Vector2(968, 160)
 	scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
 	scroll_container.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	scroll_container.follow_focus = true
@@ -56,7 +67,7 @@ func _build_ui() -> void:
 	seed_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	seed_container.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	seed_container.alignment = BoxContainer.ALIGNMENT_BEGIN
-	seed_container.add_theme_constant_override("separation", 12)
+	seed_container.add_theme_constant_override("separation", 14)
 	scroll_container.add_child(seed_container)
 
 	for seed_id_value in available_seeds:
@@ -64,7 +75,7 @@ func _build_ui() -> void:
 		var button := Button.new()
 		button.name = "%sSeedButton" % seed_id.capitalize()
 		button.text = PlantData.get_display_name(seed_id)
-		button.custom_minimum_size = Vector2(132, 118)
+		button.custom_minimum_size = Vector2(140, 132)
 		button.focus_mode = Control.FOCUS_NONE
 		_apply_seed_button_theme(button)
 		button.pressed.connect(_on_seed_button_pressed.bind(seed_id))
@@ -97,11 +108,11 @@ func _apply_seed_button_theme(button: Button) -> void:
 	button.add_theme_stylebox_override("hover", hover_style)
 	button.add_theme_stylebox_override("pressed", hover_style)
 	button.add_theme_stylebox_override("disabled", disabled_style)
-	button.add_theme_color_override("font_color", TEXT_COLOR)
-	button.add_theme_color_override("font_hover_color", TEXT_COLOR)
-	button.add_theme_color_override("font_pressed_color", TEXT_COLOR)
-	button.add_theme_color_override("font_disabled_color", TEXT_COLOR)
-	button.add_theme_font_size_override("font_size", 18)
+	button.add_theme_color_override("font_color", TEXT_DEEP)
+	button.add_theme_color_override("font_hover_color", TEXT_DEEP)
+	button.add_theme_color_override("font_pressed_color", TEXT_DEEP)
+	button.add_theme_color_override("font_disabled_color", TEXT_DEEP)
+	button.add_theme_font_size_override("font_size", 20)
 
 func _on_seed_button_pressed(seed_id: String) -> void:
 	selected_seed_id = seed_id
@@ -112,7 +123,7 @@ func _update_selection_ui() -> void:
 	if selected_seed_label == null:
 		return
 
-	selected_seed_label.text = "Selected seed: %s" % PlantData.get_display_name(selected_seed_id)
+	selected_seed_label.text = "Selected: %s" % PlantData.get_display_name(selected_seed_id)
 
 	for seed_id in seed_buttons.keys():
 		var button: Button = seed_buttons[seed_id]

--- a/scripts/ui/seed_bar.gd
+++ b/scripts/ui/seed_bar.gd
@@ -4,15 +4,19 @@ extends Control
 signal seed_selected(seed_id: String)
 
 const TEXT_DEEP := Color("#263D25")
-const TEXT_SOFT := Color("#4A5C42")
 const SEED_SLOT_TEXTURE_PATH := "res://assets/ui/seed_bar/ui_seed_slot.svg"
 const SEED_SLOT_SELECTED_TEXTURE_PATH := "res://assets/ui/seed_bar/ui_seed_slot_selected.svg"
+
+const BAR_WIDTH := 968
+const BAR_HEIGHT := 170
+const SLOT_HEIGHT := 158
+const SLOT_GAP := 12
+const SLOT_MIN_WIDTH := 96
+const SLOT_MAX_WIDTH := 150
 
 var available_seeds: Array = []
 var selected_seed_id := "carrot"
 var seed_buttons: Dictionary = {}
-var heading_label: Label
-var selected_seed_label: Label
 var scroll_container: ScrollContainer
 var seed_container: HBoxContainer
 
@@ -30,79 +34,71 @@ func set_selected_seed(seed_id: String) -> void:
 	_update_selection_ui()
 
 func _build_ui() -> void:
-	if heading_label != null:
+	if scroll_container != null:
 		return
 
-	size = Vector2(968, 220)
-
-	heading_label = Label.new()
-	heading_label.name = "HeadingLabel"
-	heading_label.text = "Seeds"
-	heading_label.position = Vector2(0, 0)
-	heading_label.size = Vector2(300, 36)
-	heading_label.add_theme_color_override("font_color", TEXT_DEEP)
-	heading_label.add_theme_font_size_override("font_size", 24)
-	add_child(heading_label)
-
-	selected_seed_label = Label.new()
-	selected_seed_label.name = "SelectedSeedLabel"
-	selected_seed_label.position = Vector2(300, 0)
-	selected_seed_label.size = Vector2(668, 36)
-	selected_seed_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	selected_seed_label.add_theme_color_override("font_color", TEXT_SOFT)
-	selected_seed_label.add_theme_font_size_override("font_size", 22)
-	add_child(selected_seed_label)
+	size = Vector2(BAR_WIDTH, BAR_HEIGHT)
 
 	scroll_container = ScrollContainer.new()
 	scroll_container.name = "SeedScrollContainer"
-	scroll_container.position = Vector2(0, 50)
-	scroll_container.size = Vector2(968, 160)
+	scroll_container.position = Vector2(0, 0)
+	scroll_container.size = Vector2(BAR_WIDTH, BAR_HEIGHT)
 	scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
 	scroll_container.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	scroll_container.follow_focus = true
+	scroll_container.scroll_deadzone = 12
 	add_child(scroll_container)
 
 	seed_container = HBoxContainer.new()
 	seed_container.name = "SeedContainer"
-	seed_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	seed_container.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	seed_container.alignment = BoxContainer.ALIGNMENT_BEGIN
-	seed_container.add_theme_constant_override("separation", 14)
+	seed_container.alignment = BoxContainer.ALIGNMENT_CENTER
+	seed_container.add_theme_constant_override("separation", SLOT_GAP)
 	scroll_container.add_child(seed_container)
+
+	var slot_width: int = _compute_slot_width(available_seeds.size())
 
 	for seed_id_value in available_seeds:
 		var seed_id := str(seed_id_value)
 		var button := Button.new()
 		button.name = "%sSeedButton" % seed_id.capitalize()
 		button.text = PlantData.get_display_name(seed_id)
-		button.custom_minimum_size = Vector2(140, 132)
+		button.custom_minimum_size = Vector2(slot_width, SLOT_HEIGHT)
 		button.focus_mode = Control.FOCUS_NONE
 		_apply_seed_button_theme(button)
 		button.pressed.connect(_on_seed_button_pressed.bind(seed_id))
 		seed_container.add_child(button)
 		seed_buttons[seed_id] = button
 
+func _compute_slot_width(seed_count: int) -> int:
+	if seed_count <= 0:
+		return SLOT_MAX_WIDTH
+
+	var available_width: int = BAR_WIDTH - (seed_count - 1) * SLOT_GAP
+	var ideal_width: int = int(float(available_width) / float(seed_count))
+	return clampi(ideal_width, SLOT_MIN_WIDTH, SLOT_MAX_WIDTH)
+
 func _apply_seed_button_theme(button: Button) -> void:
 	var normal_style := StyleBoxTexture.new()
 	normal_style.texture = load(SEED_SLOT_TEXTURE_PATH)
-	normal_style.content_margin_left = 14
-	normal_style.content_margin_top = 14
-	normal_style.content_margin_right = 14
-	normal_style.content_margin_bottom = 14
+	normal_style.content_margin_left = 12
+	normal_style.content_margin_top = 12
+	normal_style.content_margin_right = 12
+	normal_style.content_margin_bottom = 12
 
 	var hover_style := StyleBoxTexture.new()
 	hover_style.texture = load(SEED_SLOT_SELECTED_TEXTURE_PATH)
-	hover_style.content_margin_left = 14
-	hover_style.content_margin_top = 14
-	hover_style.content_margin_right = 14
-	hover_style.content_margin_bottom = 14
+	hover_style.content_margin_left = 12
+	hover_style.content_margin_top = 12
+	hover_style.content_margin_right = 12
+	hover_style.content_margin_bottom = 12
 
 	var disabled_style := StyleBoxTexture.new()
 	disabled_style.texture = load(SEED_SLOT_SELECTED_TEXTURE_PATH)
-	disabled_style.content_margin_left = 14
-	disabled_style.content_margin_top = 14
-	disabled_style.content_margin_right = 14
-	disabled_style.content_margin_bottom = 14
+	disabled_style.content_margin_left = 12
+	disabled_style.content_margin_top = 12
+	disabled_style.content_margin_right = 12
+	disabled_style.content_margin_bottom = 12
 
 	button.add_theme_stylebox_override("normal", normal_style)
 	button.add_theme_stylebox_override("hover", hover_style)
@@ -112,7 +108,7 @@ func _apply_seed_button_theme(button: Button) -> void:
 	button.add_theme_color_override("font_hover_color", TEXT_DEEP)
 	button.add_theme_color_override("font_pressed_color", TEXT_DEEP)
 	button.add_theme_color_override("font_disabled_color", TEXT_DEEP)
-	button.add_theme_font_size_override("font_size", 20)
+	button.add_theme_font_size_override("font_size", 18)
 
 func _on_seed_button_pressed(seed_id: String) -> void:
 	selected_seed_id = seed_id
@@ -120,11 +116,6 @@ func _on_seed_button_pressed(seed_id: String) -> void:
 	seed_selected.emit(seed_id)
 
 func _update_selection_ui() -> void:
-	if selected_seed_label == null:
-		return
-
-	selected_seed_label.text = "Selected: %s" % PlantData.get_display_name(selected_seed_id)
-
 	for seed_id in seed_buttons.keys():
 		var button: Button = seed_buttons[seed_id]
 		button.disabled = seed_id == selected_seed_id


### PR DESCRIPTION
Group the title, harvest counter, hint, goal, and progress bars into a
single cream header panel; turn the bed selector into highlighted tabs;
wrap the grid in a soil-colored frame; replace the flat controls
backdrop with a rounded cream panel that holds the seed bar, a moss
primary 'Water Garden' button, and a two-card status + diary panel.
Make GardenGrid's vertical start position configurable so the grid
sits centered inside the new frame.